### PR TITLE
add settings to 42 cpp devcontainer

### DIFF
--- a/42_cpp_devcontainer/devcontainer.json
+++ b/42_cpp_devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"build": {
 		"dockerfile": "Dockerfile"
-	  },
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -12,7 +12,16 @@
 				"ms-vscode.cpptools-extension-pack",
 				"ms-vscode.cpptools-themes",
 				"twxs.cmake"
-			]
+			],
+			"settings": {
+				"42header.email": "bazuara@student.42madrid.com",
+				"42header.username": "bazuara",
+				"C_Cpp.clang_format_fallbackStyle": "Google",
+				"C_Cpp.autoAddFileAssociations": false,
+				"editor.formatOnPaste": true,
+				"editor.formatOnSave": true,
+				"git.openRepositoryInParentFolders": "never"
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `42_cpp_devcontainer/devcontainer.json` file to add various settings for the development environment. The most important changes include adding user-specific settings, configuring code formatting preferences, and setting up Git behavior.

Development environment settings:

* Added user email and username settings for the 42header extension.
* Configured the fallback style for `clang_format` to "Google".
* Disabled automatic file associations in the C/C++ extension.
* Enabled automatic formatting on paste and save in the editor.
* Set Git to never open repositories in parent folders automatically.